### PR TITLE
MAAS-60 | Fix duplicate routes

### DIFF
--- a/gtfs/api/routes.py
+++ b/gtfs/api/routes.py
@@ -20,7 +20,9 @@ class RouteSerializer(serializers.ModelSerializer):
 
 
 class RouteFilter(filters.FilterSet):
-    stop_id = filters.UUIDFilter(field_name="trips__stop_times__stop__api_id")
+    stop_id = filters.UUIDFilter(
+        field_name="trips__stop_times__stop__api_id", distinct=True
+    )
 
     class Meta:
         model: Route


### PR DESCRIPTION
When routes were filttered by `stop_id`, same route was returned multiple times.