### PR TITLE
MAAS-85 | Pass extra parameters from booking API to ticketing systems

### DIFF
--- a/bookings/api.py
+++ b/bookings/api.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from bookings.models import Booking
-from bookings.serializers import BookingSerializer
+from bookings.serializers import BookingSerializer, PassthroughParametersSerializer
 
 
 class BookingViewSet(
@@ -21,7 +21,10 @@ class BookingViewSet(
     @action(detail=True, methods=["post"])
     def confirm(self, request, api_id=None):
         booking = self.get_object()
-        tickets = booking.confirm()
+
+        passthrough_parameters = PassthroughParametersSerializer(data=request.data)
+        passthrough_parameters.is_valid(raise_exception=True)
+        tickets = booking.confirm(passthrough_parameters.validated_data)
 
         booking_data = self.serializer_class(instance=booking).data
         booking_data["tickets"] = tickets

--- a/bookings/models.py
+++ b/bookings/models.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from urllib.parse import urljoin
 from uuid import uuid4
 
@@ -21,10 +22,10 @@ class TicketingSystemAPI:
         url = self.ticketing_system.api_url
         return self._post(url, ticket_data)
 
-    def confirm(self, identifier: str):
+    def confirm(self, identifier: str, passed_parameters: Optional[dict] = None):
         url = urljoin(self.ticketing_system.api_url, f"{identifier}/confirm/")
 
-        return self._post(url, {})
+        return self._post(url, passed_parameters or {})
 
     def _post(self, url: str, data):
         from bookings.serializers import ApiBookingSerializer
@@ -103,12 +104,12 @@ class Booking(TimestampedModel):
     def __str__(self):
         return f"Booking {self.api_id} ({self.status})"
 
-    def confirm(self):
+    def confirm(self, passed_parameters=None):
         """Confirm the booking and return ticket information."""
         self.status = Booking.Status.CONFIRMED
 
         api = TicketingSystemAPI(self.ticketing_system, self.maas_operator)
-        response_data = api.confirm(self.source_id)
+        response_data = api.confirm(self.source_id, passed_parameters=passed_parameters)
 
         self.source_id = response_data["id"]
         self.save()

--- a/bookings/models.py
+++ b/bookings/models.py
@@ -30,7 +30,7 @@ class TicketingSystemAPI:
         from bookings.serializers import ApiBookingSerializer
 
         payload = ApiBookingSerializer(
-            {"maas_operator": self.maas_operator, **data}
+            {**data, "maas_operator": self.maas_operator}
         ).data
 
         if not self.ticketing_system.api_key:

--- a/bookings/tests/snapshots/snap_test_api_call.py
+++ b/bookings/tests/snapshots/snap_test_api_call.py
@@ -7,13 +7,17 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_api_call_for_confirmation 1"] = {
-    "maas_operator_id": "identifier of maas operator 1"
+    "locale": "fi",
+    "maas_operator_id": "identifier of maas operator 1",
+    "request_id": "requestID",
+    "transaction_id": "transactionID",
 }
 
 snapshots["test_api_call_for_reservation 1"] = {
     "departures": [{"date": "2021-04-28", "trip_id": "source_id of trip 1"}],
     "locale": "fi",
     "maas_operator_id": "identifier of maas operator 1",
+    "request_id": "requestID",
     "route_id": "source_id of route 1",
     "tickets": [
         {
@@ -21,4 +25,5 @@ snapshots["test_api_call_for_reservation 1"] = {
             "ticket_type_id": "source_id of test fare 1",
         }
     ],
+    "transaction_id": "transactionID",
 }

--- a/bookings/tests/test_api.py
+++ b/bookings/tests/test_api.py
@@ -45,6 +45,41 @@ def test_create_booking(maas_api_client, has_route, fare_test_data, requests_moc
 
 
 @pytest.mark.django_db
+def test_create_booking_passes_extra_parameters(
+    maas_api_client, fare_test_data, requests_mock
+):
+    ticketing_system = fare_test_data.feed.ticketing_system
+    requests_mock.post(
+        ticketing_system.api_url,
+        json=get_reservation_data(),
+        status_code=status.HTTP_201_CREATED,
+    )
+    extra_params = {
+        "request_id": "requestID",
+        "transaction_id": "transactionID",
+        "locale": "sv",
+    }
+    post_data = {
+        "route_id": fare_test_data.routes[0].api_id,
+        "departure_ids": [fare_test_data.departures[0].api_id],
+        "tickets": [
+            {
+                "customer_type_id": fare_test_data.rider_categories[0].api_id,
+                "ticket_type_id": fare_test_data.fares[0].api_id,
+            }
+        ],
+        **extra_params,
+    }
+
+    maas_api_client.post(ENDPOINT, post_data)
+
+    assert requests_mock.call_count == 1
+    request_data = requests_mock.request_history[0].json()
+    for key, value in extra_params.items():
+        assert request_data[key] == value
+
+
+@pytest.mark.django_db
 def test_create_booking_no_permission(maas_api_client, fare_test_data, snapshot):
     data = {
         "route": fare_test_data.routes[0].api_id,
@@ -133,7 +168,6 @@ def test_confirm_booking(maas_api_client, requests_mock, snapshot, source_id_cha
         ticketing_system=feed.ticketing_system,
     )
     ticketing_system = feed.ticketing_system
-
     expected_source_id = (
         str(uuid.uuid4()) if source_id_changes else reserved_booking.source_id
     )
@@ -149,10 +183,37 @@ def test_confirm_booking(maas_api_client, requests_mock, snapshot, source_id_cha
     assert {"id", "status", "tickets"} == set(response.data.keys())
     snapshot.assert_match(response.data["tickets"])
     assert Booking.objects.count() == 1
-
     booking = Booking.objects.get(pk=reserved_booking.pk)
     assert booking.status == Booking.Status.CONFIRMED
     assert booking.source_id == expected_source_id
+
+
+@pytest.mark.django_db
+def test_confirm_booking_passes_extra_parameters(maas_api_client, requests_mock):
+    feed = get_feed_for_maas_operator(maas_api_client.maas_operator, True)
+    extra_params = {
+        "request_id": "requestID",
+        "transaction_id": "transactionID",
+        "locale": "sv",
+    }
+    reserved_booking = baker.make(
+        Booking,
+        maas_operator=maas_api_client.maas_operator,
+        ticketing_system=feed.ticketing_system,
+    )
+    ticketing_system = feed.ticketing_system
+    requests_mock.post(
+        urljoin(ticketing_system.api_url, f"{reserved_booking.source_id}/confirm/"),
+        json=get_confirmations_data(reserved_booking.source_id, include_qr=False),
+        status_code=status.HTTP_200_OK,
+    )
+
+    maas_api_client.post(f"{ENDPOINT}{reserved_booking.api_id}/confirm/", extra_params)
+
+    assert requests_mock.call_count == 1
+    request_data = requests_mock.request_history[0].json()
+    for key, value in extra_params.items():
+        assert request_data[key] == value
 
 
 @pytest.mark.django_db

--- a/bookings/tests/test_api_call.py
+++ b/bookings/tests/test_api_call.py
@@ -29,6 +29,8 @@ def test_api_call_for_reservation(
             }
         ],
         "locale": "fi",
+        "request_id": "requestID",
+        "transaction_id": "transactionID",
     }
 
     Booking.objects.create_reservation(maas_operator, ticketing_system, ticket_data)
@@ -40,6 +42,11 @@ def test_api_call_for_reservation(
 @pytest.mark.django_db
 def test_api_call_for_confirmation(maas_operator, requests_mock, snapshot):
     feed = get_feed_for_maas_operator(maas_operator, True)
+    extra_params = {
+        "locale": "fi",
+        "request_id": "requestID",
+        "transaction_id": "transactionID",
+    }
     reserved_booking = baker.make(
         Booking,
         maas_operator=maas_operator,
@@ -53,7 +60,7 @@ def test_api_call_for_confirmation(maas_operator, requests_mock, snapshot):
         status_code=status.HTTP_200_OK,
     )
 
-    reserved_booking.confirm()
+    reserved_booking.confirm(passed_parameters=extra_params)
 
     assert requests_mock.call_count == 1
     snapshot.assert_match(requests_mock.request_history[0].json())


### PR DESCRIPTION
This PR adds `request_id` and `transaction_id` parameters to the booking API (also `locale`) and passes these parameters to the ticketing system APIs.