### PR TITLE
Use long name in routes

### DIFF
--- a/gtfs/api/routes.py
+++ b/gtfs/api/routes.py
@@ -48,7 +48,7 @@ class RouteSerializer(serializers.ModelSerializer):
         )
 
     id = serializers.UUIDField(source="api_id")
-    name = serializers.CharField(source="short_name")
+    name = serializers.CharField(source="long_name")
     stops = serializers.SerializerMethodField()
     agency = AgencySerializer(read_only=True)
     ticket_types = serializers.SerializerMethodField()
@@ -61,9 +61,7 @@ class RouteSerializer(serializers.ModelSerializer):
             .order_by("id")
         )
         return StopSerializer(
-            stops,
-            many=True,
-            context=dict(**self.context, route_id=obj.id),
+            stops, many=True, context=dict(**self.context, route_id=obj.id)
         ).data
 
     def get_ticket_types(self, obj):

--- a/gtfs/models/route.py
+++ b/gtfs/models/route.py
@@ -42,9 +42,7 @@ class Route(TranslatableModel, GTFSModelWithSourceID):
         url=models.URLField(verbose_name=_("URL"), blank=True),
     )
     agency = models.ForeignKey(
-        Agency,
-        verbose_name=_("agency"),
-        on_delete=models.CASCADE,
+        Agency, verbose_name=_("agency"), on_delete=models.CASCADE
     )
     short_name = models.CharField(
         verbose_name=_("short name"), max_length=32, blank=True
@@ -70,8 +68,6 @@ class Route(TranslatableModel, GTFSModelWithSourceID):
 
     def __str__(self):
         try:
-            return self.short_name or self.safe_translation_getter(
-                "long_name", any_language=True
-            )
+            return self.safe_translation_getter("long_name", any_language=True)
         except TranslationDoesNotExist:
             return super().__str__()

--- a/gtfs/tests/test_routes_api.py
+++ b/gtfs/tests/test_routes_api.py
@@ -96,13 +96,9 @@ def test_routes_departures(maas_api_client, snapshot, filters, route_with_depart
 @pytest.mark.django_db
 def test_route_ordering(maas_api_client):
     feed = get_feed_for_maas_operator(maas_api_client.maas_operator, True)
-    baker.make(
-        Route,
-        feed=feed,
-        short_name=iter(["third", "first", "second"]),
-        sort_order=iter([3, 1, 2]),
-        _quantity=3,
-    )
+    baker.make(Route, feed=feed, long_name="third", sort_order=3)
+    baker.make(Route, feed=feed, long_name="first", sort_order=1)
+    baker.make(Route, feed=feed, long_name="second", sort_order=2)
 
     response = maas_api_client.get(ENDPOINT)
     assert response.status_code == 200


### PR DESCRIPTION
Use `long_name` instead of `short_name` as `name` in routes API