### PR TITLE
MAAS-98 | Bump Django to the latest 3.2 LTS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,17 @@ default_language_version:
     python: python3
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.5b0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
       - id: flake8
         exclude: "migrations"
         additional_dependencies: [pep8-naming, flake8-bugbear]
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
+    rev: 5.8.0
     hooks:
       - id: isort
         exclude: "migrations"

--- a/maritime_maas/settings.py
+++ b/maritime_maas/settings.py
@@ -48,6 +48,8 @@ ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 DATABASES = {"default": env.db()}
 DATABASES["default"]["ENGINE"] = "django.contrib.gis.db.backends.postgis"
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 LANGUAGES = (("fi", "Finnish"), ("en", "English"), ("sv", "Swedish"))
 TICKET_LANGUAGES = tuple(lang for lang, _ in LANGUAGES)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via black
 appnope==0.1.2
     # via ipython
-asgiref==3.3.1
+asgiref==3.3.4
     # via
     #   -c requirements.txt
     #   django
@@ -21,7 +21,7 @@ autoflake==1.4
     # via -r requirements-dev.in
 backcall==0.2.0
     # via ipython
-black==20.8b1
+black==21.5b0
     # via -r requirements-dev.in
 certifi==2020.12.5
     # via
@@ -37,19 +37,19 @@ click==7.1.2
     #   black
 coverage==5.5
     # via pytest-cov
-decorator==4.4.2
+decorator==5.0.7
     # via ipython
-django==3.1.7
+django==3.2.1
     # via
     #   -c requirements.txt
     #   model-bakery
 fastdiff==0.2.0
     # via snapshottest
-flake8-bugbear==20.11.1
+flake8-bugbear==21.4.3
     # via -r requirements-dev.in
 flake8-polyfill==1.0.2
     # via pep8-naming
-flake8==3.8.4
+flake8==3.9.1
     # via
     #   -r requirements-dev.in
     #   flake8-bugbear
@@ -64,21 +64,23 @@ iniconfig==1.1.1
     # via pytest
 ipython-genutils==0.2.0
     # via traitlets
-ipython==7.21.0
+ipython==7.23.1
     # via -r requirements-dev.in
-isort==5.7.0
+isort==5.8.0
     # via -r requirements-dev.in
 jedi==0.18.0
     # via ipython
+matplotlib-inline==0.1.2
+    # via ipython
 mccabe==0.6.1
     # via flake8
-model-bakery==1.2.1
+model-bakery==1.3.1
     # via -r requirements-dev.in
 mypy-extensions==0.4.3
     # via black
 packaging==20.9
     # via pytest
-parso==0.8.1
+parso==0.8.2
     # via jedi
 pathspec==0.8.1
     # via black
@@ -90,27 +92,27 @@ pickleshare==0.7.5
     # via ipython
 pluggy==0.13.1
     # via pytest
-prompt-toolkit==3.0.16
+prompt-toolkit==3.0.18
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
 py==1.10.0
     # via pytest
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via flake8
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via
     #   autoflake
     #   flake8
-pygments==2.8.0
+pygments==2.9.0
     # via ipython
 pyparsing==2.4.7
     # via packaging
 pytest-cov==2.11.1
     # via -r requirements-dev.in
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements-dev.in
-pytest==6.2.2
+pytest==6.2.4
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -123,15 +125,15 @@ pytz==2021.1
     # via
     #   -c requirements.txt
     #   django
-regex==2020.11.13
+regex==2021.4.4
     # via black
-requests-mock==1.8.0
+requests-mock==1.9.2
     # via -r requirements-dev.in
 requests==2.25.1
     # via
     #   -c requirements.txt
     #   requests-mock
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements.txt
     #   python-dateutil
@@ -150,12 +152,10 @@ toml==0.10.2
     #   black
     #   pytest
 traitlets==5.0.5
-    # via ipython
-typed-ast==1.4.2
-    # via black
-typing-extensions==3.7.4.3
-    # via black
-urllib3==1.26.3
+    # via
+    #   ipython
+    #   matplotlib-inline
+urllib3==1.26.4
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-asgiref==3.3.1
+asgiref==3.3.4
     # via django
 attrs==20.3.0
     # via fiona
@@ -32,7 +32,7 @@ django-filter==2.4.0
     # via -r requirements.in
 django-parler==2.2
     # via -r requirements.in
-django==3.1.7
+django==3.2.1
     # via
     #   -r requirements.in
     #   django-cors-headers
@@ -40,17 +40,17 @@ django==3.1.7
     #   djangorestframework
 djangorestframework-gis==0.17
     # via -r requirements.in
-djangorestframework==3.12.2
+djangorestframework==3.12.4
     # via
     #   -r requirements.in
     #   djangorestframework-gis
-fiona==1.8.18
+fiona==1.8.19
     # via geopandas
 folium==0.12.1
     # via gtfs-kit
 geopandas==0.9.0
     # via gtfs-kit
-gtfs-kit==5.0.2
+gtfs-kit==5.1.1
     # via -r requirements.in
 idna==2.10
     # via requests
@@ -64,11 +64,11 @@ markupsafe==1.1.1
     # via jinja2
 munch==2.5.0
     # via fiona
-numpy==1.20.1
+numpy==1.20.2
     # via
     #   folium
     #   pandas
-pandas==1.2.3
+pandas==1.2.4
     # via
     #   geopandas
     #   gtfs-kit
@@ -90,19 +90,19 @@ requests==2.25.1
     #   gtfs-kit
 rtree==0.9.7
     # via gtfs-kit
-sentry-sdk==0.20.3
+sentry-sdk==1.0.0
     # via -r requirements.in
 shapely==1.7.1
     # via
     #   geopandas
     #   gtfs-kit
-six==1.15.0
+six==1.16.0
     # via
     #   fiona
     #   python-dateutil
 sqlparse==0.4.1
     # via django
-urllib3==1.26.3
+urllib3==1.26.4
     # via
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
Also bumps every other requirement.