### PR TITLE
MAAS-98 | Bump Django to 3.2.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,13 +6,11 @@
 #
 appdirs==1.4.4
     # via black
-appnope==0.1.2
-    # via ipython
 asgiref==3.3.4
     # via
     #   -c requirements.txt
     #   django
-attrs==20.3.0
+attrs==21.1.0
     # via
     #   -c requirements.txt
     #   flake8-bugbear
@@ -39,7 +37,7 @@ coverage==5.5
     # via pytest-cov
 decorator==5.0.7
     # via ipython
-django==3.2.1
+django==3.2.2
     # via
     #   -c requirements.txt
     #   model-bakery

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.3.4
     # via django
-attrs==20.3.0
+attrs==21.1.0
     # via fiona
 branca==0.4.2
     # via folium
@@ -32,7 +32,7 @@ django-filter==2.4.0
     # via -r requirements.in
 django-parler==2.2
     # via -r requirements.in
-django==3.2.1
+django==3.2.2
     # via
     #   -r requirements.in
     #   django-cors-headers


### PR DESCRIPTION
A new bugfix to Django was just released.

Refs MAAS-98