### PR TITLE
Use "Bearer token" for this API and ticketing system API calls

### DIFF
--- a/bookings/tests/test_api_call.py
+++ b/bookings/tests/test_api_call.py
@@ -37,6 +37,7 @@ def test_api_call_for_reservation(
 
     assert requests_mock.call_count == 1
     snapshot.assert_match(requests_mock.request_history[0].json())
+    assert requests_mock.request_history[0].headers["Authorization"] == "Bearer APIKEY"
 
 
 @pytest.mark.django_db
@@ -64,3 +65,4 @@ def test_api_call_for_confirmation(maas_operator, requests_mock, snapshot):
 
     assert requests_mock.call_count == 1
     snapshot.assert_match(requests_mock.request_history[0].json())
+    assert requests_mock.request_history[0].headers["Authorization"] == "Bearer APIKEY"

--- a/bookings/utils.py
+++ b/bookings/utils.py
@@ -8,5 +8,5 @@ class TokenAuth(AuthBase):
         self.token = token
 
     def __call__(self, r):
-        r.headers["authorization"] = "Token " + self.token
+        r.headers["authorization"] = "Bearer " + self.token
         return r

--- a/frontend/src/common/util/axios.ts
+++ b/frontend/src/common/util/axios.ts
@@ -5,6 +5,6 @@ import Config from '../../domain/config';
 export const axiosInstance = axios.create({
   baseURL: Config.baseUrl,
   headers: {
-    authorization: `ApiKey ${Config.apiKey}`,
+    authorization: `Bearer ${Config.apiKey}`,
   },
 });

--- a/maas/authentication.py
+++ b/maas/authentication.py
@@ -1,5 +1,5 @@
 from rest_framework.authentication import TokenAuthentication
 
 
-class ApiKeyAuthentication(TokenAuthentication):
-    keyword = "ApiKey"
+class BearerTokenAuthentication(TokenAuthentication):
+    keyword = "Bearer"

--- a/maas/tests/utils.py
+++ b/maas/tests/utils.py
@@ -3,6 +3,6 @@ from rest_framework.authtoken.models import Token
 
 def token_authenticate(api_client, user):
     token, _ = Token.objects.get_or_create(user=user)
-    api_client.credentials(HTTP_AUTHORIZATION="ApiKey " + token.key)
+    api_client.credentials(HTTP_AUTHORIZATION="Bearer " + token.key)
     api_client.auth_user = user
     return api_client

--- a/maritime_maas/settings.py
+++ b/maritime_maas/settings.py
@@ -158,7 +158,7 @@ TEMPLATES = [
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["maas.permissions.IsMaasOperator"],
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "maas.authentication.ApiKeyAuthentication",
+        "maas.authentication.BearerTokenAuthentication",
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],

--- a/mock_ticket_api/api.py
+++ b/mock_ticket_api/api.py
@@ -14,6 +14,7 @@ class MockTicketParamsSerializer(serializers.Serializer):
 class MockTicketViewSet(viewsets.ViewSet):
 
     permission_classes = [permissions.AllowAny]
+    authentication_classes = []
     serializer_class = MockTicketParamsSerializer
 
     def create(self, request):

--- a/mock_ticket_api/tests/test_ticket_api.py
+++ b/mock_ticket_api/tests/test_ticket_api.py
@@ -11,7 +11,7 @@ from rest_framework.test import APIClient
 @pytest.fixture
 def ticket_api_client():
     api_client = APIClient()
-    api_client.credentials(HTTP_AUTHORIZATION="Token 70k3n")
+    api_client.credentials(HTTP_AUTHORIZATION="Bearer 70k3n")
     return api_client
 
 


### PR DESCRIPTION
Authorization header was excepted to contain API token prefixed with a `ApiKey` keyword when this API was used. For ticketing system API calls the token was prefixed with `Token` keyword. This PR unifies the behavior and uses `Bearer` prefix everywhere.