### PR TITLE
MAAS-88 | Error handling

### DIFF
--- a/bookings/choices.py
+++ b/bookings/choices.py
@@ -1,0 +1,7 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class BookingStatus(models.TextChoices):
+    RESERVED = "RESERVED", _("Reserved")
+    CONFIRMED = "CONFIRMED", _("Confirmed")

--- a/bookings/exception_handler.py
+++ b/bookings/exception_handler.py
@@ -1,0 +1,29 @@
+import logging
+
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler as original_exception_handler
+
+from bookings.ticketing_system import (
+    TicketingSystemNotBehavingError,
+    TicketingSystemRequestError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_error_response(exc):
+    return Response(
+        {"error": {"code": exc.code, "message": exc.message, "details": exc.details}},
+        status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+    )
+
+
+def exception_handler(exc, context):
+    if isinstance(exc, TicketingSystemRequestError):
+        return _get_error_response(exc)
+    elif isinstance(exc, TicketingSystemNotBehavingError):
+        logger.error(exc)
+        return _get_error_response(exc)
+    else:
+        return original_exception_handler(exc, context)

--- a/bookings/models.py
+++ b/bookings/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 from parler.utils.context import switch_language
 
+from bookings.choices import BookingStatus
 from bookings.ticketing_system import TicketingSystemAPI
 from gtfs.models.base import TimestampedModel
 from maas.models import MaasOperator, TicketingSystem
@@ -38,10 +39,7 @@ class BookingQueryset(models.QuerySet):
 
 
 class Booking(TimestampedModel):
-    class Status(models.TextChoices):
-        RESERVED = "RESERVED", _("Reserved")
-        CONFIRMED = "CONFIRMED", _("Confirmed")
-
+    Status = BookingStatus  # solving circular importing issues beautifully here
     source_id = models.CharField(verbose_name=_("source ID"), max_length=255)
     api_id = models.UUIDField(verbose_name=_("API ID"), unique=True, default=uuid4)
     maas_operator = models.ForeignKey(

--- a/bookings/models.py
+++ b/bookings/models.py
@@ -1,52 +1,12 @@
-from typing import Optional
-from urllib.parse import urljoin
 from uuid import uuid4
 
-import requests
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from parler.utils.context import switch_language
 
-from bookings.utils import TokenAuth
+from bookings.ticketing_system import TicketingSystemAPI
 from gtfs.models.base import TimestampedModel
 from maas.models import MaasOperator, TicketingSystem
-
-
-class TicketingSystemAPI:
-    TIMEOUT = 10
-
-    def __init__(self, ticketing_system: TicketingSystem, maas_operator: MaasOperator):
-        self.ticketing_system = ticketing_system
-        self.maas_operator = maas_operator
-
-    def reserve(self, ticket_data: dict):
-        url = self.ticketing_system.api_url
-        return self._post(url, ticket_data)
-
-    def confirm(self, identifier: str, passed_parameters: Optional[dict] = None):
-        url = urljoin(self.ticketing_system.api_url, f"{identifier}/confirm/")
-
-        return self._post(url, passed_parameters or {})
-
-    def _post(self, url: str, data):
-        from bookings.serializers import ApiBookingSerializer
-
-        payload = ApiBookingSerializer(
-            {**data, "maas_operator": self.maas_operator}
-        ).data
-
-        if not self.ticketing_system.api_key:
-            raise Exception("Ticketing system doesn't define an API key.")
-
-        response = requests.post(
-            url,
-            json=payload,
-            timeout=self.TIMEOUT,
-            auth=TokenAuth(self.ticketing_system.api_key),
-        )
-
-        response.raise_for_status()
-        return response.json()
 
 
 class BookingQueryset(models.QuerySet):

--- a/bookings/tests/snapshots/snap_test_api.py
+++ b/bookings/tests/snapshots/snap_test_api.py
@@ -109,3 +109,87 @@ snapshots["test_create_booking_no_permission 1"] = {
         'Invalid ID "00000000-0000-0000-0000-000000000004" - object does not exist.'
     ]
 }
+
+snapshots["test_ticketing_system_confirm_errors[None-200-confirmation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
+
+snapshots["test_ticketing_system_confirm_errors[None-200-reservation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
+
+snapshots["test_ticketing_system_confirm_errors[None-400-confirmation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
+
+snapshots["test_ticketing_system_confirm_errors[None-400-reservation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response0-422-confirmation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response0-422-reservation] 1"
+] = {"error": {"code": "MAX_CAPACITY_EXCEEDED", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response1-400-confirmation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response1-400-reservation] 1"
+] = {
+    "error": {
+        "code": "MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED",
+        "details": "",
+        "message": "Maximum number of tickets requested exceeded.",
+    }
+}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response2-400-confirmation] 1"
+] = {
+    "error": {
+        "code": "BOOKING_EXPIRED",
+        "details": "Your booking has been totally expired.",
+        "message": "Booking expired.",
+    }
+}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response2-400-reservation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response3-422-confirmation] 1"
+] = {"error": {"code": "BOOKING_ALREADY_CONFIRMED", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response3-422-reservation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response4-400-confirmation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response4-400-reservation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response5-400-confirmation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response5-400-reservation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response6-500-confirmation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_confirm_errors[ticketing_api_response6-500-reservation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}

--- a/bookings/tests/snapshots/snap_test_api.py
+++ b/bookings/tests/snapshots/snap_test_api.py
@@ -110,37 +110,35 @@ snapshots["test_create_booking_no_permission 1"] = {
     ]
 }
 
-snapshots["test_ticketing_system_confirm_errors[None-200-confirmation] 1"] = {
+snapshots["test_ticketing_system_errors[None-200-confirmation] 1"] = {
     "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
 }
 
-snapshots["test_ticketing_system_confirm_errors[None-200-reservation] 1"] = {
+snapshots["test_ticketing_system_errors[None-200-reservation] 1"] = {
     "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
 }
 
-snapshots["test_ticketing_system_confirm_errors[None-400-confirmation] 1"] = {
+snapshots["test_ticketing_system_errors[None-400-confirmation] 1"] = {
     "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
 }
 
-snapshots["test_ticketing_system_confirm_errors[None-400-reservation] 1"] = {
+snapshots["test_ticketing_system_errors[None-400-reservation] 1"] = {
     "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
 }
 
 snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response0-422-confirmation] 1"
+    "test_ticketing_system_errors[ticketing_api_response0-422-confirmation] 1"
 ] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
 
-snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response0-422-reservation] 1"
-] = {"error": {"code": "MAX_CAPACITY_EXCEEDED", "details": "", "message": ""}}
+snapshots["test_ticketing_system_errors[ticketing_api_response0-422-reservation] 1"] = {
+    "error": {"code": "MAX_CAPACITY_EXCEEDED", "details": "", "message": ""}
+}
 
 snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response1-400-confirmation] 1"
+    "test_ticketing_system_errors[ticketing_api_response1-400-confirmation] 1"
 ] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
 
-snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response1-400-reservation] 1"
-] = {
+snapshots["test_ticketing_system_errors[ticketing_api_response1-400-reservation] 1"] = {
     "error": {
         "code": "MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED",
         "details": "",
@@ -149,7 +147,31 @@ snapshots[
 }
 
 snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response2-400-confirmation] 1"
+    "test_ticketing_system_errors[ticketing_api_response10-201-confirmation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_errors[ticketing_api_response10-201-reservation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_errors[ticketing_api_response11-201-confirmation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_errors[ticketing_api_response11-201-reservation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_errors[ticketing_api_response12-201-confirmation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_errors[ticketing_api_response12-201-reservation] 1"
+] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_errors[ticketing_api_response2-400-confirmation] 1"
 ] = {
     "error": {
         "code": "BOOKING_EXPIRED",
@@ -158,38 +180,46 @@ snapshots[
     }
 }
 
-snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response2-400-reservation] 1"
-] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+snapshots["test_ticketing_system_errors[ticketing_api_response2-400-reservation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
 
 snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response3-422-confirmation] 1"
+    "test_ticketing_system_errors[ticketing_api_response3-422-confirmation] 1"
 ] = {"error": {"code": "BOOKING_ALREADY_CONFIRMED", "details": "", "message": ""}}
 
-snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response3-422-reservation] 1"
-] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+snapshots["test_ticketing_system_errors[ticketing_api_response3-422-reservation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
 
 snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response4-400-confirmation] 1"
+    "test_ticketing_system_errors[ticketing_api_response4-400-confirmation] 1"
 ] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
 
-snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response4-400-reservation] 1"
-] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+snapshots["test_ticketing_system_errors[ticketing_api_response4-400-reservation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
 
 snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response5-400-confirmation] 1"
+    "test_ticketing_system_errors[ticketing_api_response5-400-confirmation] 1"
 ] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
 
-snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response5-400-reservation] 1"
-] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+snapshots["test_ticketing_system_errors[ticketing_api_response5-400-reservation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
 
 snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response6-500-confirmation] 1"
+    "test_ticketing_system_errors[ticketing_api_response6-500-confirmation] 1"
 ] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
 
+snapshots["test_ticketing_system_errors[ticketing_api_response6-500-reservation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}
+
 snapshots[
-    "test_ticketing_system_confirm_errors[ticketing_api_response6-500-reservation] 1"
+    "test_ticketing_system_errors[ticketing_api_response9-200-confirmation] 1"
 ] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
+
+snapshots["test_ticketing_system_errors[ticketing_api_response9-200-reservation] 1"] = {
+    "error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}
+}

--- a/bookings/tests/test_api.py
+++ b/bookings/tests/test_api.py
@@ -256,40 +256,50 @@ def test_confirm_booking_not_own(maas_api_client):
     [
         (
             {
-                "code": "MAX_CAPACITY_EXCEEDED",
+                "error": {
+                    "code": "MAX_CAPACITY_EXCEEDED",
+                }
             },
             422,
         ),
         (
             {
-                "code": "MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED",
-                "message": "Maximum number of tickets requested exceeded.",
+                "error": {
+                    "code": "MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED",
+                    "message": "Maximum number of tickets requested exceeded.",
+                }
             },
             400,
         ),
         (
             {
-                "code": "BOOKING_EXPIRED",
-                "message": "Booking expired.",
-                "details": "Your booking has been totally expired.",
+                "error": {
+                    "code": "BOOKING_EXPIRED",
+                    "message": "Booking expired.",
+                    "details": "Your booking has been totally expired.",
+                }
             },
             400,
         ),
         (
             {
-                "code": "BOOKING_ALREADY_CONFIRMED",
+                "error": {
+                    "code": "BOOKING_ALREADY_CONFIRMED",
+                }
             },
             422,
         ),
         (
             {
-                "code": "BOGUS_CODE",
+                "error": {
+                    "code": "BOGUS_CODE",
+                }
             },
             400,
         ),
-        ({"no_code": "at_all"}, 400),
+        ({"error": {"no_code": "at_all"}}, 400),
         (
-            {"code": "BOOKING_EXPIRED"},
+            {"error": {"code": "BOOKING_EXPIRED"}},
             500,
         ),
         (
@@ -300,10 +310,26 @@ def test_confirm_booking_not_own(maas_api_client):
             None,
             200,
         ),
+        (
+            {},
+            200,
+        ),
+        (
+            {"id": "xyz"},
+            201,
+        ),
+        (
+            {"ID": "id_field_should_be_lowercase", "status": "RESERVED"},
+            201,
+        ),
+        (
+            {"id": "xyz", "status": "BOGUS_STATUS"},
+            201,
+        ),
     ],
 )
 @pytest.mark.django_db
-def test_ticketing_system_confirm_errors(
+def test_ticketing_system_errors(
     maas_operator,
     requests_mock,
     maas_api_client,
@@ -317,8 +343,8 @@ def test_ticketing_system_confirm_errors(
     ticketing_system = fare_test_data.feed.ticketing_system
 
     data_params = (
-        {"json": {"error": ticketing_api_response}}
-        if ticketing_api_response
+        {"json": ticketing_api_response}
+        if ticketing_api_response is not None
         else {"text": "no json"}
     )
 

--- a/bookings/ticketing_system.py
+++ b/bookings/ticketing_system.py
@@ -1,0 +1,108 @@
+from json import JSONDecodeError
+from typing import Optional
+from urllib.parse import urljoin
+
+import requests
+from requests import RequestException
+from rest_framework import serializers
+
+from maas.models import MaasOperator, TicketingSystem
+
+from .utils import TokenAuth
+
+reservation_error_codes = (
+    "MAX_CAPACITY_EXCEEDED",
+    "MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED",
+)
+
+confirmation_error_codes = (
+    "BOOKING_EXPIRED",
+    "BOOKING_ALREADY_CONFIRMED",
+)
+
+
+class TicketingSystemRequestError(Exception):
+    def __init__(self, code, message=None, details=None):
+        self.code = code
+        self.message = message or ""
+        self.details = details or ""
+
+
+class TicketingSystemNotBehavingError(Exception):
+    code = "TICKET_SYSTEM_ERROR"
+    message = ""
+    details = ""
+
+    def __init__(self, response):
+        self.response = response
+
+    def __str__(self):
+        return (
+            f"Ticketing system error: {self.__cause__} "
+            f"response: ({self.response.status_code}) {self.response.content}"
+        )
+
+
+class InnerReservationErrorSerializer(serializers.Serializer):
+    code = serializers.ChoiceField(choices=reservation_error_codes)
+    message = serializers.CharField(required=False)
+    details = serializers.CharField(required=False)
+
+
+class InnerConfirmationErrorSerializer(serializers.Serializer):
+    code = serializers.ChoiceField(choices=confirmation_error_codes)
+    message = serializers.CharField(required=False)
+    details = serializers.CharField(required=False)
+
+
+class ReservationErrorSerializer(serializers.Serializer):
+    error = InnerReservationErrorSerializer()
+
+
+class ConfirmationErrorSerializer(serializers.Serializer):
+    error = InnerConfirmationErrorSerializer()
+
+
+class TicketingSystemAPI:
+    TIMEOUT = 10
+
+    def __init__(self, ticketing_system: TicketingSystem, maas_operator: MaasOperator):
+        self.ticketing_system = ticketing_system
+        self.maas_operator = maas_operator
+
+    def reserve(self, ticket_data: dict):
+        url = self.ticketing_system.api_url
+        return self._post(url, ticket_data, ReservationErrorSerializer)
+
+    def confirm(self, identifier: str, passed_parameters: Optional[dict] = None):
+        url = urljoin(self.ticketing_system.api_url, f"{identifier}/confirm/")
+        return self._post(url, passed_parameters or {}, ConfirmationErrorSerializer)
+
+    def _post(self, url: str, data, error_serializer):
+        from bookings.serializers import ApiBookingSerializer
+
+        payload = ApiBookingSerializer(
+            {**data, "maas_operator": self.maas_operator}
+        ).data
+
+        if not self.ticketing_system.api_key:
+            raise Exception("Ticketing system doesn't define an API key.")
+
+        response = requests.post(
+            url,
+            json=payload,
+            timeout=self.TIMEOUT,
+            auth=TokenAuth(self.ticketing_system.api_key),
+        )
+
+        try:
+            data = response.json()
+            if 400 <= response.status_code <= 499:
+                serializer = error_serializer(data=data)
+                serializer.is_valid(raise_exception=True)
+                raise TicketingSystemRequestError(**serializer.data["error"])
+            response.raise_for_status()
+        except (JSONDecodeError, serializers.ValidationError, RequestException) as e:
+            raise TicketingSystemNotBehavingError(response=response) from e
+
+        return data

--- a/maritime_maas/settings.py
+++ b/maritime_maas/settings.py
@@ -163,6 +163,7 @@ REST_FRAMEWORK = {
         "maas.authentication.BearerTokenAuthentication",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "EXCEPTION_HANDLER": "bookings.exception_handler.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }
 if DEBUG:

--- a/mock_ticket_api/api.py
+++ b/mock_ticket_api/api.py
@@ -5,12 +5,17 @@ from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from mock_ticket_api.utils import get_confirmations_data, get_reservation_data
+from mock_ticket_api.utils import (
+    get_confirmations_data,
+    get_error_data,
+    get_reservation_data,
+)
 
 
 class MockTicketParamsSerializer(serializers.Serializer):
     maas_operator_id = serializers.CharField()
     locale = serializers.ChoiceField(choices=settings.TICKET_LANGUAGES, required=False)
+    request_id = serializers.CharField(required=False)
 
 
 @extend_schema_view(
@@ -28,6 +33,12 @@ class MockTicketViewSet(viewsets.ViewSet):
         if not params.is_valid():
             return Response(params.errors, status=status.HTTP_400_BAD_REQUEST)
 
+        if error_data := get_error_data(params.data.get("request_id")):
+            return Response(
+                error_data,
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+
         return Response(get_reservation_data(), status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["post"])
@@ -35,5 +46,11 @@ class MockTicketViewSet(viewsets.ViewSet):
         params = self.serializer_class(data=request.data)
         if not params.is_valid():
             return Response(params.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        if error_data := get_error_data(params.data.get("request_id")):
+            return Response(
+                error_data,
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
 
         return Response(get_confirmations_data(pk), status=status.HTTP_200_OK)

--- a/mock_ticket_api/utils.py
+++ b/mock_ticket_api/utils.py
@@ -58,3 +58,27 @@ def get_confirmations_data(pk, include_qr=True) -> dict:
             }
         ],
     }
+
+
+def get_error_data(error_code):
+    errors = {
+        "MAX_CAPACITY_EXCEEDED": {
+            "code": "MAX_CAPACITY_EXCEEDED",
+        },
+        "MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED": {
+            "code": "MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED",
+            "message": "Maximum number of tickets requested exceeded.",
+        },
+        "BOOKING_EXPIRED": {
+            "code": "BOOKING_EXPIRED",
+            "message": "Booking expired.",
+            "details": "Your booking has totally expired.",
+        },
+        "BOOKING_ALREADY_CONFIRMED": {
+            "code": "BOOKING_ALREADY_CONFIRMED",
+        },
+        "TICKET_SYSTEM_ERROR": {"code": "TICKET_SYSTEM_ERROR"},
+    }
+    if error := errors.get(error_code):
+        return {"error": error}
+    return None


### PR DESCRIPTION
Implemented better error handling to ticket system API calls. Ticket systems should respond to known error situations with response

```
{
     "error": {
        "code": <error code>,
        "message": <optional message, meant for users>,
        "details": <optional details, meant for users>
     }
}
```

HTTP status code of the response should be 400-499.

When an error happens, our booking API endpoint returns the same response with status code 422 to users.

Currently supported error codes:
    * for reservation: `MAX_CAPACITY_EXCEEDED`,
      `MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED`
    * for confirmation: `BOOKING_EXPIRED`, `BOOKING_ALREADY_CONFIRMED`

When we get an error response from a ticket system API that does not conform to those rules, our API will return error code `TICKET_SYSTEM_ERROR`. The same error code is returned also when a successful response does not pass validation.

It is possible to test these errors with the mock ticket system API by providing an error code in `request_id` field.