### PR TITLE
MAAS-82 | Disable basic and session authentication for the API

### DIFF
--- a/maritime_maas/settings.py
+++ b/maritime_maas/settings.py
@@ -165,6 +165,10 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }
+if DEBUG:
+    REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].append(
+        "rest_framework.authentication.SessionAuthentication"
+    )
 
 SPECTACULAR_SETTINGS = {
     "TITLE": _("Maritime MaaS API"),

--- a/maritime_maas/settings.py
+++ b/maritime_maas/settings.py
@@ -161,8 +161,6 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["maas.permissions.IsMaasOperator"],
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "maas.authentication.BearerTokenAuthentication",
-        "rest_framework.authentication.BasicAuthentication",
-        "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",


### PR DESCRIPTION
API allowed to use multiple ways to authenticate with the API, this PR leaves only the Bearer token authentication method. Session authentication is also enabled when debugging.