### PR TITLE
MAAS-82 | Hide mock ticket system API from generated schema and documentation

### DIFF
--- a/mock_ticket_api/api.py
+++ b/mock_ticket_api/api.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import action
@@ -14,8 +13,7 @@ class MockTicketParamsSerializer(serializers.Serializer):
 
 
 @extend_schema_view(
-    create=extend_schema(summary=_("Create a mock booking")),
-    confirm=extend_schema(summary=_("Confirm a previously created mock booking")),
+    create=extend_schema(exclude=True), confirm=extend_schema(exclude=True)
 )
 class MockTicketViewSet(viewsets.ViewSet):
 


### PR DESCRIPTION
Mock ticket system API is not part of the official API.