### PR TITLE
MAAS-101 | Fix StopSerializer.departures not using distinct StopTimes

### DIFF
--- a/gtfs/tests/conftest.py
+++ b/gtfs/tests/conftest.py
@@ -35,12 +35,7 @@ def api_id_generator():
 
 
 @pytest.fixture
-def route_with_departures(maas_operator, api_id_generator):
-    """
-    A route with
-        * 2 trips each having 2 stops and 2 stop times
-        * 3 departures (first trip having two departures on separate days)
-    """
+def route_for_maas_operator(maas_operator, api_id_generator):
     feed = get_feed_for_maas_operator(maas_operator, True)
 
     agency = baker.make(
@@ -63,6 +58,20 @@ def route_with_departures(maas_operator, api_id_generator):
         url="url of test route ",
         capacity_sales=Route.CapacitySales.DISABLED,
     )
+
+    return route
+
+
+@pytest.fixture
+def route_with_departures(api_id_generator, route_for_maas_operator):
+    """
+    A route with
+        * 2 trips each having 2 stops and 2 stop times
+        * 3 departures (first trip having two departures on separate days)
+    """
+    route = route_for_maas_operator
+    feed = route_for_maas_operator.feed
+
     trips = baker.make(
         Trip,
         route=route,

--- a/gtfs/tests/snapshots/snap_test_stops_api.py
+++ b/gtfs/tests/snapshots/snap_test_stops_api.py
@@ -111,3 +111,36 @@ snapshots["test_stops_departures[filters5] 1"] = [
 ]
 
 snapshots["test_stops_departures[filters6] 1"] = []
+
+snapshots["test_stops_departures__stop_appears_multiple_times_in_trip 1"] = [
+    {
+        "arrival_time": "2021-02-18T07:00:00Z",
+        "bikes_allowed": 0,
+        "block_id": "block_id of test trip 1",
+        "departure_headsign": "headsign of test trip ",
+        "departure_time": "2021-02-18T08:00:00Z",
+        "direction_id": 0,
+        "id": "00000000-0000-0000-0000-000000000004",
+        "route_id": "00000000-0000-0000-0000-000000000000",
+        "short_name": "short_name of test trip ",
+        "stop_headsign": "stop_headsign of test stop time ",
+        "stop_sequence": 2,
+        "timepoint": 1,
+        "wheelchair_accessible": 0,
+    },
+    {
+        "arrival_time": "2021-02-18T09:00:00Z",
+        "bikes_allowed": 0,
+        "block_id": "block_id of test trip 1",
+        "departure_headsign": "headsign of test trip ",
+        "departure_time": "2021-02-18T10:00:00Z",
+        "direction_id": 0,
+        "id": "00000000-0000-0000-0000-000000000004",
+        "route_id": "00000000-0000-0000-0000-000000000000",
+        "short_name": "short_name of test trip ",
+        "stop_headsign": "stop_headsign of test stop time ",
+        "stop_sequence": 4,
+        "timepoint": 1,
+        "wheelchair_accessible": 0,
+    },
+]


### PR DESCRIPTION
This PR fixes an issue where the API was not returning distinct StopTimes (departures in the API) when a stop appeared more than once on a trip. If the same stop appeared more than once on a trip (when visiting the same place more than once during a trip), the API didn't properly return the stop times for additional visits to the same stop.