### PR TITLE
MAAS-108 | Fix Feed importer fingerprint logic

### DIFF
--- a/gtfs/admin.py
+++ b/gtfs/admin.py
@@ -63,6 +63,7 @@ class FeedAdmin(admin.ModelAdmin):
     readonly_fields = (
         "created_at",
         "imported_at",
+        "fingerprint",
         "import_attempted_at",
         "last_import_successful",
         "last_import_error_message",
@@ -93,7 +94,12 @@ class FeedAdmin(admin.ModelAdmin):
         if not obj:
             return ((None, {"fields": ("name", "url_or_path", "ticketing_system")}),)
 
-        import_fields = ("imported_at", "import_attempted_at", "last_import_successful")
+        import_fields = (
+            "imported_at",
+            "import_attempted_at",
+            "fingerprint",
+            "last_import_successful",
+        )
         if obj.last_import_successful is False:
             import_fields += ("last_import_error_message",)
 

--- a/gtfs/importers/gtfs_feed_reader.py
+++ b/gtfs/importers/gtfs_feed_reader.py
@@ -144,13 +144,13 @@ class GTFSFeedReader:
         fingerprint = None
 
         try:
-            response = requests.head(feed.name)
+            response = requests.head(feed.url_or_path)
             response.raise_for_status()
             if timestamp := response.headers.get("last-modified"):
                 fingerprint = timestamp
 
             if not fingerprint:
-                response = requests.get(feed.name)
+                response = requests.get(feed.url_or_path)
                 response.raise_for_status()
                 sha1 = hashlib.sha1()
                 sha1.update(response.content)

--- a/gtfs/tests/test_importers.py
+++ b/gtfs/tests/test_importers.py
@@ -27,7 +27,7 @@ def test_gtfs_feed_importer():
     importer = GTFSFeedImporter()
     importer.run(feed)
 
-    assert feed.fingerprint == datetime.date.today().isoformat()
+    assert feed.fingerprint == localdate().isoformat()
 
     assert Agency.objects.count() == 1
     agency = Agency.objects.first()


### PR DESCRIPTION
Use the new `Feed.url_or_path?` for fetching the Feed. Previously the name field did contain the url.