### PR TITLE
MAAS-107 | Make safe_translation_getter return a str default value

### DIFF
--- a/gtfs/models/agency.py
+++ b/gtfs/models/agency.py
@@ -1,6 +1,6 @@
 from django.contrib.gis.db import models
 from django.utils.translation import gettext_lazy as _
-from parler.models import TranslatableModel, TranslatedFields, TranslationDoesNotExist
+from parler.models import TranslatableModel, TranslatedFields
 
 from gtfs.models.base import GTFSModelWithSourceID
 
@@ -33,7 +33,6 @@ class Agency(TranslatableModel, GTFSModelWithSourceID):
         default_related_name = "agencies"
 
     def __str__(self):
-        try:
-            return self.safe_translation_getter("name", any_language=True)
-        except TranslationDoesNotExist:
-            return super().__str__()
+        return self.safe_translation_getter(
+            "name", default=super().__str__, any_language=True
+        )

--- a/gtfs/models/rider_category.py
+++ b/gtfs/models/rider_category.py
@@ -10,7 +10,7 @@ This file is needed because standard GTFS does not include these fields.
 """
 from django.contrib.gis.db import models
 from django.utils.translation import gettext_lazy as _
-from parler.models import TranslatableModel, TranslatedFields, TranslationDoesNotExist
+from parler.models import TranslatableModel, TranslatedFields
 
 from .base import GTFSModelWithSourceID
 
@@ -33,7 +33,6 @@ class RiderCategory(TranslatableModel, GTFSModelWithSourceID):
         verbose_name_plural = _("rider categories")
 
     def __str__(self):
-        try:
-            return self.safe_translation_getter("name", any_language=True)
-        except TranslationDoesNotExist:
-            return super().__str__()
+        return self.safe_translation_getter(
+            "name", default=super().__str__, any_language=True
+        )

--- a/gtfs/models/route.py
+++ b/gtfs/models/route.py
@@ -1,7 +1,7 @@
 from django.contrib.gis.db import models
 from django.utils.translation import gettext_lazy as _
 from parler.managers import TranslatableQuerySet
-from parler.models import TranslatableModel, TranslatedFields, TranslationDoesNotExist
+from parler.models import TranslatableModel, TranslatedFields
 
 from maas.models import MaasOperator
 
@@ -67,7 +67,6 @@ class Route(TranslatableModel, GTFSModelWithSourceID):
         default_related_name = "routes"
 
     def __str__(self):
-        try:
-            return self.safe_translation_getter("long_name", any_language=True)
-        except TranslationDoesNotExist:
-            return super().__str__()
+        return self.safe_translation_getter(
+            "long_name", default=super().__str__, any_language=True
+        )

--- a/gtfs/models/stop.py
+++ b/gtfs/models/stop.py
@@ -1,7 +1,7 @@
 from django.contrib.gis.db import models
 from django.utils.translation import gettext_lazy as _
 from parler.managers import TranslatableQuerySet
-from parler.models import TranslatableModel, TranslatedFields, TranslationDoesNotExist
+from parler.models import TranslatableModel, TranslatedFields
 
 from maas.models import MaasOperator
 
@@ -48,7 +48,6 @@ class Stop(TranslatableModel, GTFSModelWithSourceID):
         default_related_name = "stops"
 
     def __str__(self):
-        try:
-            return self.safe_translation_getter("name", any_language=True)
-        except TranslationDoesNotExist:
-            return super().__str__()
+        return self.safe_translation_getter(
+            "name", default=super().__str__, any_language=True
+        )

--- a/gtfs/models/trip.py
+++ b/gtfs/models/trip.py
@@ -52,4 +52,6 @@ class Trip(TranslatableModel, GTFSModelWithSourceID):
         default_related_name = "trips"
 
     def __str__(self):
-        return self.short_name or super().__str__()
+        return self.safe_translation_getter(
+            "short_name", default=super().__str__, any_language=True
+        )


### PR DESCRIPTION
This PR fixes e.g. issues experienced in Django admin due to missing translations.

Also adds `safe_translation_getter` to Trip.