### PR TITLE
MAAS-114 | Add ticket system error code TICKET_SALES_ENDED

### DIFF
--- a/bookings/tests/snapshots/snap_test_api.py
+++ b/bookings/tests/snapshots/snap_test_api.py
@@ -211,6 +211,14 @@ snapshots[
 ] = {"error": {"code": "TICKET_SYSTEM_ERROR", "details": "", "message": ""}}
 
 snapshots[
+    "test_ticketing_system_errors[ticketing_api_response15-422-confirmation] 1"
+] = {"error": {"code": "TICKET_SALES_ENDED", "details": "", "message": ""}}
+
+snapshots[
+    "test_ticketing_system_errors[ticketing_api_response15-422-reservation] 1"
+] = {"error": {"code": "TICKET_SALES_ENDED", "details": "", "message": ""}}
+
+snapshots[
     "test_ticketing_system_errors[ticketing_api_response2-400-confirmation] 1"
 ] = {
     "error": {

--- a/bookings/tests/test_api.py
+++ b/bookings/tests/test_api.py
@@ -412,6 +412,14 @@ def test_confirm_booking_not_own(maas_api_client):
             },
             422,
         ),
+        (
+            {
+                "error": {
+                    "code": "TICKET_SALES_ENDED",
+                }
+            },
+            422,
+        ),
     ],
 )
 @pytest.mark.django_db

--- a/bookings/ticketing_system.py
+++ b/bookings/ticketing_system.py
@@ -18,11 +18,13 @@ logger = logging.getLogger(__name__)
 reservation_error_codes = (
     "MAX_CAPACITY_EXCEEDED",
     "MAX_NUMBER_OF_TICKETS_REQUESTED_EXCEEDED",
+    "TICKET_SALES_ENDED",
 )
 
 confirmation_error_codes = (
     "BOOKING_EXPIRED",
     "BOOKING_ALREADY_CONFIRMED",
+    "TICKET_SALES_ENDED",
 )
 
 


### PR DESCRIPTION
Added new error code `TICKET_SALES_ENDED` to possible error codes from ticket systems to the MAAS operator client. The code can be used on both the reservation request and the confirmation request.