### PR TITLE
Public endpoints access: routes, shapes and stops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 .idea
 docker-compose.env.yaml
+kubeconfig

--- a/gtfs/tests/conftest.py
+++ b/gtfs/tests/conftest.py
@@ -22,10 +22,25 @@ def maas_operator():
 
 
 @pytest.fixture
+def second_maas_operator():
+    return baker.make(
+        MaasOperator,
+        name=seq("name of maas operator 2"),
+        identifier=seq("identifier of maas operator 2"),
+    )
+
+
+@pytest.fixture
 def maas_api_client(maas_operator):
     api_client = APIClient()
     token_authenticate(api_client, maas_operator.user)
     api_client.maas_operator = maas_operator
+    return api_client
+
+
+@pytest.fixture
+def maas_unauthenticated_api_client():
+    api_client = APIClient()
     return api_client
 
 
@@ -60,6 +75,55 @@ def route_for_maas_operator(maas_operator, api_id_generator):
     )
 
     return route
+
+
+@pytest.fixture
+def route_for_second_tsp(second_maas_operator, api_id_generator):
+    feed = get_feed_for_maas_operator(maas_operator, False)
+
+    agency = baker.make(
+        Agency,
+        feed=feed,
+        name="test agency 2",
+        url="www.testagency.com",
+        logo_url="www.testagency.com/logo",
+        timezone="Europe/Helsinki",
+        email="test-agency@example.com",
+        phone="777777",
+    )
+
+    route = baker.make(
+        Route,
+        feed=feed,
+        api_id=api_id_generator,
+        agency=agency,
+        desc="desc of test route 2",
+        url="url of test route 2",
+        capacity_sales=Route.CapacitySales.DISABLED,
+    )
+
+    return route
+
+
+@pytest.fixture
+def stops_from_second_tsp(api_id_generator, route_for_second_tsp):
+    """
+    A route with 2 stops
+    """
+    feed = route_for_second_tsp.feed
+
+    stops = baker.make(
+        Stop,
+        feed=feed,
+        api_id=api_id_generator,
+        name="stop ",
+        tts_name="tts_name of stop ",
+        code=seq("code of stop"),
+        desc="desc of test stop ",
+        _quantity=2,
+    )
+
+    return stops
 
 
 @pytest.fixture

--- a/gtfs/tests/snapshots/snap_test_routes_api.py
+++ b/gtfs/tests/snapshots/snap_test_routes_api.py
@@ -72,6 +72,90 @@ snapshots["test_routes 1"] = [
     }
 ]
 
+snapshots["test_routes[filters0] 1"] = [
+    {
+        "agency": {
+            "email": "test-agency@example.com",
+            "logo_url": "www.testagency.com/logo",
+            "name": "test agency",
+            "phone": "777777",
+            "url": "www.testagency.com",
+        },
+        "capacity_sales": 0,
+        "description": "desc of test route ",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "",
+        "stops": [
+            {
+                "description": "desc of test stop ",
+                "id": "00000000-0000-0000-0000-000000000001",
+                "name": "stop ",
+                "tts_name": "tts_name of stop ",
+                "wheelchair_boarding": 0,
+            },
+            {
+                "description": "desc of test stop ",
+                "id": "00000000-0000-0000-0000-000000000002",
+                "name": "stop ",
+                "tts_name": "tts_name of stop ",
+                "wheelchair_boarding": 0,
+            },
+        ],
+        "ticket_types": [],
+        "url": "url of test route ",
+    },
+    {
+        "agency": {
+            "email": "test-agency@example.com",
+            "logo_url": "www.testagency.com/logo",
+            "name": "test agency 2",
+            "phone": "777777",
+            "url": "www.testagency.com",
+        },
+        "capacity_sales": 0,
+        "description": "desc of test route 2",
+        "id": "00000000-0000-0000-0000-000000000006",
+        "name": "",
+        "stops": [],
+        "ticket_types": [],
+        "url": "url of test route 2",
+    },
+]
+
+snapshots["test_routes[filters1] 1"] = [
+    {
+        "agency": {
+            "email": "test-agency@example.com",
+            "logo_url": "www.testagency.com/logo",
+            "name": "test agency",
+            "phone": "777777",
+            "url": "www.testagency.com",
+        },
+        "capacity_sales": 0,
+        "description": "desc of test route ",
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "",
+        "stops": [
+            {
+                "description": "desc of test stop ",
+                "id": "00000000-0000-0000-0000-000000000001",
+                "name": "stop ",
+                "tts_name": "tts_name of stop ",
+                "wheelchair_boarding": 0,
+            },
+            {
+                "description": "desc of test stop ",
+                "id": "00000000-0000-0000-0000-000000000002",
+                "name": "stop ",
+                "tts_name": "tts_name of stop ",
+                "wheelchair_boarding": 0,
+            },
+        ],
+        "ticket_types": [],
+        "url": "url of test route ",
+    }
+]
+
 snapshots["test_routes_departures[filters2] 1"] = [
     {
         "arrival_time": "2021-02-18T13:00:00Z",

--- a/gtfs/tests/snapshots/snap_test_stops_api.py
+++ b/gtfs/tests/snapshots/snap_test_stops_api.py
@@ -6,7 +6,38 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_stops 1"] = [
+snapshots["test_stops[filters0] 1"] = [
+    {
+        "description": "desc of test stop ",
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "stop ",
+        "tts_name": "tts_name of stop ",
+        "wheelchair_boarding": 0,
+    },
+    {
+        "description": "desc of test stop ",
+        "id": "00000000-0000-0000-0000-000000000002",
+        "name": "stop ",
+        "tts_name": "tts_name of stop ",
+        "wheelchair_boarding": 0,
+    },
+    {
+        "description": "desc of test stop ",
+        "id": "00000000-0000-0000-0000-000000000007",
+        "name": "stop ",
+        "tts_name": "tts_name of stop ",
+        "wheelchair_boarding": 0,
+    },
+    {
+        "description": "desc of test stop ",
+        "id": "00000000-0000-0000-0000-000000000008",
+        "name": "stop ",
+        "tts_name": "tts_name of stop ",
+        "wheelchair_boarding": 0,
+    },
+]
+
+snapshots["test_stops[filters1] 1"] = [
     {
         "description": "desc of test stop ",
         "id": "00000000-0000-0000-0000-000000000001",

--- a/gtfs/tests/test_routes_api.py
+++ b/gtfs/tests/test_routes_api.py
@@ -19,8 +19,18 @@ ENDPOINT = "/v1/routes/"
 
 
 @pytest.mark.django_db
-def test_routes(maas_api_client, route_with_departures, snapshot):
-    response = maas_api_client.get(ENDPOINT)
+@pytest.mark.parametrize(
+    "filters",
+    (
+        {"api_client": "maas_unauthenticated_api_client"},
+        {"api_client": "maas_api_client"},
+    ),
+)
+def test_routes(
+    request, route_with_departures, snapshot, filters, stops_from_second_tsp
+):
+    api_client = request.getfixturevalue(filters["api_client"])
+    response = api_client.get(ENDPOINT)
     assert response.status_code == 200
 
     content = json.loads(response.content)

--- a/gtfs/tests/test_stops_api.py
+++ b/gtfs/tests/test_stops_api.py
@@ -19,10 +19,19 @@ def api_id_generator():
 
 
 @pytest.mark.django_db
-def test_stops(maas_api_client, route_with_departures, snapshot):
-    response = maas_api_client.get(ENDPOINT)
+@pytest.mark.parametrize(
+    "filters",
+    (
+        {"api_client": "maas_unauthenticated_api_client"},
+        {"api_client": "maas_api_client"},
+    ),
+)
+def test_stops(
+    request, route_with_departures, snapshot, filters, stops_from_second_tsp
+):
+    api_client = request.getfixturevalue(filters["api_client"])
+    response = api_client.get(ENDPOINT)
     assert response.status_code == 200
-
     content = clean_stops_for_snapshot(json.loads(response.content))
     snapshot.assert_match(content)
 


### PR DESCRIPTION
### Description
This PR includes the following endpoints to be accessed publically:
- routes
- shapes
- stops

Authenticated users will see data related to their accounts as before.
PR includes tests.

Linked ticket [link](https://trello.com/c/8xEFSAC4/8-gtfs-feeds-as-open-feeds-to-api)
