### PR TITLE
Removing cobertura artifact from gitlabCI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,10 +64,6 @@ workflow:
     - 'eval export TEST_IMG=$IMAGE_TEST_TAG'
     - 'eval docker pull $TEST_IMG'
     - docker-compose -f docker-compose.yml -f docker-compose.test.override.yml run --rm --name unittest django
-  artifacts:
-    reports:
-      cobertura: coverage.xml
-
 
 #####
 ## WORKFLOW_FEATURES: Build image


### PR DESCRIPTION
Removing artifacts from tests gitlabCI stage.
Coverage should still be logged [here](https://github.com/arslanhashmi/maritime-maas/blob/44b8555cacf2519442e8fae3c276b3774e5639e3/docker-compose.test.override.yml#L25)